### PR TITLE
fixed:解決 Windows 版本開機重複執行問題與優化安裝路徑，並新增Windows解除安裝腳本

### DIFF
--- a/Windows-One-Click-Installer.bat
+++ b/Windows-One-Click-Installer.bat
@@ -6,6 +6,7 @@ NET SESSION >nul 2>&1
 if %errorlevel% neq 0 (
     echo #######################################################
     echo # PLEASE RUN THIS SCRIPT AS ADMINISTRATOR!            #
+    echo # Right-click -> Run as Administrator                 #
     echo #######################################################
     timeout /t 5
     exit /b 1
@@ -19,7 +20,10 @@ set PY_DIR_APPDATA=%LOCALAPPDATA%\Programs\Python\Python313
 set PY_EXE_PROGRAMFILES=%PY_DIR_PROGRAMFILES%\python.exe
 set PY_EXE_APPDATA=%PY_DIR_APPDATA%\python.exe
 set SCRIPT_URL=https://raw.githubusercontent.com/apple050620312/NCUT-Internet-Auto-Login/refs/heads/main/NCUT_Internet_Auto_Login.py
-set STARTUP_DIR="%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py"
+
+:: [CHANGED] New installation directory (Clean & Hidden from Startup folder)
+set INSTALL_DIR=%ProgramData%\NCUT_AutoLogin
+set SCRIPT_PATH=%INSTALL_DIR%\NCUT_Internet_Auto_Login.py
 
 :: Get temp folder path
 set TEMP_INSTALLER=%TEMP%\python_installer.exe
@@ -79,45 +83,49 @@ echo Setting Python as default program for .py files...
 assoc .py=Python.File >nul 2>&1
 ftype Python.File="%PY_EXE%" "%%1" %%* >nul 2>&1
 
-:: Verify file association
-reg query "HKEY_CLASSES_ROOT\.py" | find "Python.File" >nul
-if %errorlevel% neq 0 (
-    echo Warning: Failed to set Python as default for .py files using normal means
-    echo Trying force method
-    reg add "HKCR\.py" /ve /d "Python.File" /f
-    reg add "HKCR\Python.File\shell\open\command" /ve /d "\"%PY_EXE%\" \"%%1\" %%*" /f
-    reg delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.py\UserChoice" /f
-    taskkill /f /im explorer.exe
-    start explorer.exe
-)
-
-:: Rest of the script remains the same...
 :: Step 3: Install requests package
 echo Installing required packages...
 "%PY_EXE%" -m pip install requests --quiet
 
-:: Step 4: Download auto-login script
+:: Step 4: Create Directory and Download auto-login script
+echo Creating installation directory...
+if not exist "%INSTALL_DIR%" mkdir "%INSTALL_DIR%"
+
 echo Downloading NCUT login script...
-curl -o %STARTUP_DIR% %SCRIPT_URL% || (
+curl -o "%SCRIPT_PATH%" %SCRIPT_URL% || (
     echo Failed to download login script
     timeout /t 5
     exit /b 1
 )
 
-:: Step 5: Run the script
-echo Starting login service...
-start "" "%PY_EXE%" %STARTUP_DIR%
+:: [CLEANUP] Remove old script from Startup folder if exists (to prevent double run)
+if exist "%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py" (
+    echo Removing old script from Startup folder to prevent double execution...
+    del "%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py"
+)
 
-:: Create scheduled task
-schtasks /create /tn "NCUT Auto Login" /tr "\"%PY_EXE%\" \"%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py\"" /sc onlogon /ru SYSTEM /rl HIGHEST /f >nul 2>&1
+:: Step 5: Create Scheduled Task (Unattended Mode)
+echo Creating system startup task...
+
+:: /sc onstart = Runs when Windows boots (before login)
+:: /ru SYSTEM = Runs with System privileges
+:: /tn "NCUT Auto Login" = Task Name
+schtasks /create /tn "NCUT Auto Login" /tr "\"%PY_EXE%\" \"%SCRIPT_PATH%\"" /sc onstart /ru SYSTEM /rl HIGHEST /f >nul 2>&1
+
+:: Step 6: Start the script immediately (so you don't have to reboot now)
+echo Starting login service immediately...
+start "" "%PY_EXE%" "%SCRIPT_PATH%"
 
 echo #######################################################
 echo # INSTALLATION COMPLETED SUCCESSFULLY!                #
-echo # Python location: %PY_EXE%                           #
 echo #                                                     #
-echo # The login service will run:                         #
-echo #   - Immediately now                                 #
-echo #   - On every system startup                         #
+echo # Python Script Location:                             #
+echo # %SCRIPT_PATH%
+echo #                                                     #
+echo # Status:                                             #
+echo # - Unattended Mode: ACTIVE (/sc onstart)             #
+echo # - Runs automatically at BOOT (No login needed)      #
+echo # - Runs with SYSTEM privileges                       #
 echo #######################################################
 
 timeout /t 5

--- a/Windows-One-Click-Uninstall.bat
+++ b/Windows-One-Click-Uninstall.bat
@@ -1,0 +1,79 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: =======================================================
+:: Check for Administrator Privileges
+:: =======================================================
+NET SESSION >nul 2>&1
+if %errorlevel% neq 0 (
+    echo #######################################################
+    echo # ERROR: PLEASE RUN THIS SCRIPT AS ADMINISTRATOR!     #
+    echo # Right-click -> Run as Administrator                 #
+    echo #######################################################
+    timeout /t 5
+    exit /b 1
+)
+
+:: =======================================================
+:: Configuration
+:: =======================================================
+set TASK_NAME="NCUT Auto Login"
+set INSTALL_DIR=%ProgramData%\NCUT_AutoLogin
+set LEGACY_STARTUP="%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py"
+
+echo =======================================================
+echo     Uninstalling NCUT Auto Login Script...
+echo =======================================================
+
+:: =======================================================
+:: Step 1: Remove Scheduled Task
+:: =======================================================
+echo [1/3] Removing system scheduled task...
+
+:: Attempt to stop the task if it is running
+schtasks /end /tn %TASK_NAME% >nul 2>&1
+
+:: Delete the task
+schtasks /delete /tn %TASK_NAME% /f >nul 2>&1
+if %errorlevel% equ 0 (
+    echo    - Scheduled task deleted successfully.
+) else (
+    echo    - Scheduled task not found or already deleted.
+)
+
+:: =======================================================
+:: Step 2: Remove Files and Directory
+:: =======================================================
+echo [2/3] Removing script files...
+
+if exist "%INSTALL_DIR%" (
+    rmdir /s /q "%INSTALL_DIR%"
+    echo    - Removed installation directory: %INSTALL_DIR%
+) else (
+    echo    - Installation directory not found, skipping.
+)
+
+:: =======================================================
+:: Step 3: Cleanup Legacy Startup Items
+:: =======================================================
+echo [3/3] Checking for legacy startup items...
+
+if exist %LEGACY_STARTUP% (
+    del /f /q %LEGACY_STARTUP%
+    echo    - Removed script from legacy Startup folder.
+)
+
+echo.
+echo #######################################################
+echo #  UNINSTALLATION COMPLETED!                          #
+echo #                                                     #
+echo #  - Auto-login task cancelled                        #
+echo #  - Script files removed                             #
+echo #                                                     #
+echo #  NOTE: Python and 'requests' package remain         #
+echo #  installed on your system.                          #
+echo #  (To avoid affecting other Python applications)     #
+echo #######################################################
+
+timeout /t 5
+exit /b 0


### PR DESCRIPTION
### 解決的問題

- 原版的 Windows 安裝腳本同時將程式放入「啟動資料夾」並建立「工作排程」，導致開機時程式會重複執行兩次，且會彈出干擾用戶的 CMD 黑框。

### 修改內容

1. **優化安裝路徑**：將程式移出啟動資料夾，改存放在獨立目錄（%ProgramData%\NCUT_AutoLogin）。
2. **純靜默背景執行**：統一依賴「工作排程器」以 SYSTEM 權限在背景啟動，解決重複執行與黑框彈出的問題。 
3. **新增解除安裝工具**：新增Windows-One-Click-Uninstall.bat，支援一鍵完整移除工作排程、安裝目錄，並自動清理舊版殘留的檔案。