### PR TITLE
refactor(windows): 重構工作排程器 (schtasks) 建置邏輯以實作高可用性常駐服務

### DIFF
--- a/Windows-One-Click-Installer.bat
+++ b/Windows-One-Click-Installer.bat
@@ -97,29 +97,30 @@ if exist "%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Inter
     del "%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py"
 )
 
-:: Step 4: Create Scheduled Task (Unattended Mode)
-echo Creating system startup task...
-
-:: /sc onstart = Runs when Windows boots (before login)
-:: /ru SYSTEM = Runs with System privileges
-:: /tn "NCUT Auto Login" = Task Name
+:: Step 4: Create Scheduled Task (Unattended Mode + Auto Restart Protection)
+echo Creating system startup task and applying protection policies...
 schtasks /create /tn "NCUT Auto Login" /tr "\"%PY_EXE%\" \"%SCRIPT_PATH%\"" /sc onstart /ru SYSTEM /rl HIGHEST /f >nul 2>&1
+set "TASK_XML=%TEMP%\ncut_task.xml"
+schtasks /query /tn "NCUT Auto Login" /xml > "%TASK_XML%"
+
+powershell -NoProfile -Command "(Get-Content '%TASK_XML%') -replace '<ExecutionTimeLimit>.*</ExecutionTimeLimit>', '<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>' -replace '</Settings>', '<RestartOnFailure><Interval>PT1M</Interval><Count>999</Count></RestartOnFailure></Settings>' | Set-Content '%TASK_XML%'"
+schtasks /create /tn "NCUT Auto Login" /xml "%TASK_XML%" /ru SYSTEM /f >nul 2>&1
+del "%TASK_XML%" >nul 2>&1
 
 :: Step 5: Start the script immediately (so you don't have to reboot now)
 echo Starting login service immediately...
 start "" "%PY_EXE%" "%SCRIPT_PATH%"
 
-echo #######################################################
-echo # INSTALLATION COMPLETED SUCCESSFULLY!                #
-echo #                                                     #
-echo # Python Script Location:                             #
+echo ################################################################
+echo # INSTALLATION COMPLETED SUCCESSFULLY!                         #
+echo #                                                              #
+echo # Python Script Location:                                      #
 echo # %SCRIPT_PATH%
-echo #                                                     #
-echo # Status:                                             #
-echo # - Unattended Mode: ACTIVE (/sc onstart)             #
-echo # - Runs automatically at BOOT (No login needed)      #
-echo # - Runs with SYSTEM privileges                       #
-echo #######################################################
+echo #                                                              #
+echo # Status:                                                      #
+echo # - Unattended Mode: ACTIVE (/sc onstart)                      #
+echo # - Runs automatically at BOOT (No login needed)               #
+echo # - Runs with SYSTEM privileges                                #
+echo ################################################################
 
-timeout /t 5
-exit /b 0
+pause

--- a/Windows-One-Click-Uninstall.bat
+++ b/Windows-One-Click-Uninstall.bat
@@ -1,78 +1,64 @@
 @echo off
 setlocal enabledelayedexpansion
 
-:: =======================================================
-:: Check for Administrator Privileges
-:: =======================================================
+:: Check for administrator privileges
 NET SESSION >nul 2>&1
 if %errorlevel% neq 0 (
     echo #######################################################
-    echo # ERROR: PLEASE RUN THIS SCRIPT AS ADMINISTRATOR!     #
+    echo # PLEASE RUN THIS SCRIPT AS ADMINISTRATOR!            #
     echo # Right-click -> Run as Administrator                 #
     echo #######################################################
     timeout /t 5
     exit /b 1
 )
 
-:: =======================================================
-:: Configuration
-:: =======================================================
-set TASK_NAME="NCUT Auto Login"
-set INSTALL_DIR=%ProgramData%\NCUT_AutoLogin
-set LEGACY_STARTUP="%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py"
+echo =========================================
+echo   NCUT Auto Login - Uninstaller
+echo =========================================
+echo.
 
-echo =======================================================
-echo     Uninstalling NCUT Auto Login Script...
-echo =======================================================
-
-:: =======================================================
-:: Step 1: Remove Scheduled Task
-:: =======================================================
-echo [1/3] Removing system scheduled task...
-
-:: Attempt to stop the task if it is running
-schtasks /end /tn %TASK_NAME% >nul 2>&1
-
-:: Delete the task
-schtasks /delete /tn %TASK_NAME% /f >nul 2>&1
+:: 1. 停止並刪除工作排程器任務
+echo [1/4] Removing Scheduled Task...
+schtasks /delete /tn "NCUT Auto Login" /f >nul 2>&1
 if %errorlevel% equ 0 (
-    echo    - Scheduled task deleted successfully.
+    echo   - Task "NCUT Auto Login" removed successfully.
 ) else (
-    echo    - Scheduled task not found or already deleted.
+    echo   - Task not found or already removed.
 )
 
-:: =======================================================
-:: Step 2: Remove Files and Directory
-:: =======================================================
-echo [2/3] Removing script files...
+:: 2. 強制終止正在背景執行的 Python 登入腳本
+echo [2/4] Stopping background processes...
+wmic process where "name='python.exe' and commandline like '%%NCUT_Internet_Auto_Login.py%%'" call terminate >nul 2>&1
+
+:: 3. 刪除新版安裝目錄與腳本
+echo [3/4] Removing script files...
+set INSTALL_DIR=%ProgramData%\NCUT_AutoLogin
+set SCRIPT_PATH=%INSTALL_DIR%\NCUT_Internet_Auto_Login.py
+
+if exist "%SCRIPT_PATH%" (
+    del "%SCRIPT_PATH%" /f /q
+    echo   - Deleted: %SCRIPT_PATH%
+)
 
 if exist "%INSTALL_DIR%" (
-    rmdir /s /q "%INSTALL_DIR%"
-    echo    - Removed installation directory: %INSTALL_DIR%
-) else (
-    echo    - Installation directory not found, skipping.
+    rmdir "%INSTALL_DIR%" /s /q >nul 2>&1
+    echo   - Removed directory: %INSTALL_DIR%
 )
 
-:: =======================================================
-:: Step 3: Cleanup Legacy Startup Items
-:: =======================================================
-echo [3/3] Checking for legacy startup items...
-
-if exist %LEGACY_STARTUP% (
-    del /f /q %LEGACY_STARTUP% >nul 2>&1
-    echo    - Removed script from legacy Startup folder.
+:: 4. 清理舊版本 (Startup 資料夾) 的殘留檔案
+echo [4/4] Checking for legacy files...
+set OLD_SCRIPT="%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\NCUT_Internet_Auto_Login.py"
+if exist %OLD_SCRIPT% (
+    del %OLD_SCRIPT% /f /q
+    echo   - Legacy script removed from Startup.
+) else (
+    echo   - No legacy files found.
 )
 
 echo.
 echo #######################################################
-echo #  UNINSTALLATION COMPLETED!                          #
-echo #                                                     #
-echo #  - Auto-login task cancelled                        #
-echo #  - Script files removed                             #
-echo #                                                     #
-echo #  NOTE: Python remains installed on your system.     #
-echo #  (To avoid affecting other Python applications)     #
+echo # UNINSTALLATION COMPLETED SUCCESSFULLY!              #
+echo # All files and background tasks have been removed.   #
 echo #######################################################
-
-timeout /t 5
-exit /b 0
+echo.
+pause


### PR DESCRIPTION
### 變更背景與目的
目前安裝腳本依賴基礎 `schtasks` 命令列參數所建立的背景排程，受限於 Windows 工作排程器的預設規範，包含 72 小時強制中止機制，且在程序因系統資源滿載而崩潰時無法自動復原。這對於需要長期常駐的自動登入服務而言存在穩定性隱患。本次變更專注於重構排程任務的建置架構，以符合系統守護行程 (Daemon) 的運行標準。

### 主要修改內容

本次變更導入了 XML 設定檔動態注入技術 (XML Injection)。由於標準的 `schtasks` 參數無法直接配置進階的排程保護屬性，腳本中實作了「先匯出排程設定、利用 PowerShell 寫入進階屬性、再重新匯入覆蓋」的自動化流程，藉此達成以下兩項核心保護機制：

1. 實作故障自動復原 (Fault Tolerance)
   - 透過寫入 `<RestartOnFailure>` 標籤，設定當 Python 背景程序因記憶體滿載等外部異常因素被系統強制結束時，工作排程器將每隔 1 分鐘自動重新啟動該服務，並將最高容許重試次數設定為 999 次，確保服務具備自我修復能力。

2. 解除系統最高執行時限
   - 將 `<ExecutionTimeLimit>` 標籤的屬性值修改為 `PT0S`。此舉解除了 Windows 預設「連續執行 3 天即強制終止任務」的限制，確保以無限迴圈運作的常駐自動登入腳本，不會在穩定運行 72 小時後發生系統層級的突發性中斷。

### 測試與驗證
- 經本地端 Windows 環境測試，安裝腳本之 XML 匯出、PowerShell 修改與匯入覆蓋流程可無錯誤執行。
- 透過 `taskschd.msc` 檢視，確認「NCUT Auto Login」排程任務之「如果工作失敗，重新啟動頻率 (1 分鐘 / 999 次)」及「不限制最高執行時間」等進階設定皆已正確寫入並生效。